### PR TITLE
Merge changes into master

### DIFF
--- a/Clonable.Test/ArrayClone.cs
+++ b/Clonable.Test/ArrayClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class ArrayClone

--- a/Clonable.Test/Clonable.Test.csproj
+++ b/Clonable.Test/Clonable.Test.csproj
@@ -21,7 +21,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-	<ProjectReference Include="..\Cloneable\Cloneable.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	<ProjectReference Include="..\Cloneable\LoDaTek.Cloneable.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	<ProjectReference Include="..\LoDaTek.Cloneable.Core\LoDaTek.Cloneable.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Clonable.Test/DeepArrayClone.cs
+++ b/Clonable.Test/DeepArrayClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class DeepArrayClone

--- a/Clonable.Test/DeepClone.cs
+++ b/Clonable.Test/DeepClone.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Clonable.Test/DeepCloneNullable.cs
+++ b/Clonable.Test/DeepCloneNullable.cs
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+using LoDaTek.Cloneable.Core;
+
 namespace Cloneable.Sample
 {
     [Cloneable]

--- a/Clonable.Test/DeepDictionaryClone.cs
+++ b/Clonable.Test/DeepDictionaryClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class DeepDictionaryClone

--- a/Clonable.Test/DeepEnumerableClone.cs
+++ b/Clonable.Test/DeepEnumerableClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class DeepEnumerableClone

--- a/Clonable.Test/DeepListClone.cs
+++ b/Clonable.Test/DeepListClone.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using LoDaTek.Cloneable.Core;
+
 namespace Cloneable.Sample
 {
     [Cloneable]

--- a/Clonable.Test/DictionaryClone.cs
+++ b/Clonable.Test/DictionaryClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class DictionaryClone

--- a/Clonable.Test/DuplicateNameClone.cs
+++ b/Clonable.Test/DuplicateNameClone.cs
@@ -1,4 +1,5 @@
 ﻿using Cloneable;
+using LoDaTek.Cloneable.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Clonable.Test/EnumerableClone.cs
+++ b/Clonable.Test/EnumerableClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class EnumerableClone

--- a/Clonable.Test/ListClone.cs
+++ b/Clonable.Test/ListClone.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LoDaTek.Cloneable.Core;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Clonable.Test/NestedDeepListClone.cs
+++ b/Clonable.Test/NestedDeepListClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class NestedDeepListClone

--- a/Clonable.Test/NestedListClone.cs
+++ b/Clonable.Test/NestedListClone.cs
@@ -1,4 +1,6 @@
-﻿namespace Cloneable.Sample
+﻿using LoDaTek.Cloneable.Core;
+
+namespace Cloneable.Sample
 {
     [Cloneable]
     public partial class NestedListClone

--- a/Clonable.Test/SafeDeepClone.cs
+++ b/Clonable.Test/SafeDeepClone.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Clonable.Test/SimpleClone.cs
+++ b/Clonable.Test/SimpleClone.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Clonable.Test/SimpleCloneExplicit.cs
+++ b/Clonable.Test/SimpleCloneExplicit.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Cloneable.Sample/Cloneable.Sample.csproj
+++ b/Cloneable.Sample/Cloneable.Sample.csproj
@@ -7,7 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Cloneable\Cloneable.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\Cloneable\LoDaTek.Cloneable.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\LoDaTek.Cloneable.Core\LoDaTek.Cloneable.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Cloneable.Sample/DeepClone.cs
+++ b/Cloneable.Sample/DeepClone.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Cloneable.Sample/ListClone.cs
+++ b/Cloneable.Sample/ListClone.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LoDaTek.Cloneable.Core;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/Cloneable.Sample/SafeDeepClone.cs
+++ b/Cloneable.Sample/SafeDeepClone.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Cloneable.Sample/SimpleClone.cs
+++ b/Cloneable.Sample/SimpleClone.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Cloneable.Sample/SimpleCloneExplicit.cs
+++ b/Cloneable.Sample/SimpleCloneExplicit.cs
@@ -1,3 +1,4 @@
+using LoDaTek.Cloneable.Core;
 using System;
 
 namespace Cloneable.Sample

--- a/Cloneable.sln
+++ b/Cloneable.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoDaTek.Cloneable.Core", "L
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".ci", ".ci", "{B00C08D9-8E8F-49E8-8D00-27E2397AB4A8}"
 	ProjectSection(SolutionItems) = preProject
+		azure-pipelines-mergetest.yml = azure-pipelines-mergetest.yml
+		azure-pipelines-release.yml = azure-pipelines-release.yml
 		Directory.Build.props = Directory.Build.props
 		LICENCE = LICENCE
 		README.md = README.md
@@ -79,5 +81,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {15B791A9-A3E7-4DA8-8093-838AF61170E2}
 	EndGlobalSection
 EndGlobal

--- a/Cloneable.sln
+++ b/Cloneable.sln
@@ -3,11 +3,20 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cloneable", "Cloneable\Cloneable.csproj", "{8239F685-5966-47A9-BDBB-1762F6268A10}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoDaTek.Cloneable", "Cloneable\LoDaTek.Cloneable.csproj", "{8239F685-5966-47A9-BDBB-1762F6268A10}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cloneable.Sample", "Cloneable.Sample\Cloneable.Sample.csproj", "{D4425270-3428-4B0D-A084-2747C9E571F8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Clonable.Test", "Clonable.Test\Clonable.Test.csproj", "{C7F18179-5889-476D-8AF1-CF2FE2D11DDA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Clonable.Test", "Clonable.Test\Clonable.Test.csproj", "{C7F18179-5889-476D-8AF1-CF2FE2D11DDA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoDaTek.Cloneable.Core", "LoDaTek.Cloneable.Core\LoDaTek.Cloneable.Core.csproj", "{C2D8133F-3058-4EE1-B742-BC1724691098}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".ci", ".ci", "{B00C08D9-8E8F-49E8-8D00-27E2397AB4A8}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		LICENCE = LICENCE
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,6 +64,18 @@ Global
 		{C7F18179-5889-476D-8AF1-CF2FE2D11DDA}.Release|x64.Build.0 = Release|Any CPU
 		{C7F18179-5889-476D-8AF1-CF2FE2D11DDA}.Release|x86.ActiveCfg = Release|Any CPU
 		{C7F18179-5889-476D-8AF1-CF2FE2D11DDA}.Release|x86.Build.0 = Release|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Debug|x64.Build.0 = Debug|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Debug|x86.Build.0 = Debug|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Release|x64.ActiveCfg = Release|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Release|x64.Build.0 = Release|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Release|x86.ActiveCfg = Release|Any CPU
+		{C2D8133F-3058-4EE1-B742-BC1724691098}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Cloneable/CloneableGenerator.cs
+++ b/Cloneable/CloneableGenerator.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Cloneable
+namespace LoDaTek.Cloneable
 {
     [Generator]
     public class CloneableGenerator : ISourceGenerator
@@ -17,56 +17,10 @@ namespace Cloneable
         private const string PreventDeepCopyKeyString = "PreventDeepCopy";
         private const string ExplicitDeclarationKeyString = "ExplicitDeclaration";
 
-        private const string CloneableNamespace = "Cloneable";
+        private const string CloneableNamespace = "LoDaTek.Cloneable.Core";
         private const string CloneableAttributeString = "CloneableAttribute";
         private const string CloneAttributeString = "CloneAttribute";
         private const string IgnoreCloneAttributeString = "IgnoreCloneAttribute";
-
-        private const string cloneableAttributeText = @"using System;
-
-namespace " + CloneableNamespace + @"
-{
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = true, AllowMultiple = false)]
-    public sealed class " + CloneableAttributeString + @" : Attribute
-    {
-        public " + CloneableAttributeString + @"()
-        {
-        }
-
-        public bool " + ExplicitDeclarationKeyString + @" { get; set; }
-    }
-}
-";
-
-        private const string clonePropertyAttributeText = @"using System;
-
-namespace " + CloneableNamespace + @"
-{
-    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
-    public sealed class " + CloneAttributeString + @" : Attribute
-    {
-        public " + CloneAttributeString + @"()
-        {
-        }
-
-        public bool " + PreventDeepCopyKeyString + @" { get; set; }
-    }
-}
-";
-
-        private const string ignoreClonePropertyAttributeText = @"using System;
-
-namespace " + CloneableNamespace + @"
-{
-    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
-    public sealed class " + IgnoreCloneAttributeString + @" : Attribute
-    {
-        public " + IgnoreCloneAttributeString + @"()
-        {
-        }
-    }
-}
-";
 
         //TODO: Add CustomCloneAttribute?
         private INamedTypeSymbol? cloneableAttribute;
@@ -80,7 +34,6 @@ namespace " + CloneableNamespace + @"
 
         public void Execute(GeneratorExecutionContext context)
         {
-            InjectCloneableAttributes(context);
             GenerateCloneMethods(context);
         }
 
@@ -115,12 +68,7 @@ namespace " + CloneableNamespace + @"
 
         private static Compilation GetCompilation(GeneratorExecutionContext context)
         {
-            var options = context.Compilation.SyntaxTrees.First().Options as CSharpParseOptions;
-
-            var compilation = context.Compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(cloneableAttributeText, Encoding.UTF8), options)).
-                AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(clonePropertyAttributeText, Encoding.UTF8), options)).
-                AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(ignoreClonePropertyAttributeText, Encoding.UTF8), options));
-            return compilation;
+            return context.Compilation;
         }
 
         private string CreateCloneableCode(INamedTypeSymbol classSymbol, bool isExplicit)
@@ -335,11 +283,5 @@ namespace {namespaceName}
             return classSymbol;
         }
 
-        private static void InjectCloneableAttributes(GeneratorExecutionContext context)
-        {
-            context.AddSource(CloneableAttributeString, SourceText.From(cloneableAttributeText, Encoding.UTF8));
-            context.AddSource(CloneAttributeString, SourceText.From(clonePropertyAttributeText, Encoding.UTF8));
-            context.AddSource(IgnoreCloneAttributeString, SourceText.From(ignoreClonePropertyAttributeText, Encoding.UTF8));
-        }
     }
 }

--- a/Cloneable/LoDaTek.Cloneable.csproj
+++ b/Cloneable/LoDaTek.Cloneable.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Authors>newky2k</Authors>
+		<Description>Auto-generator of Clone method using C# Source Generator</Description>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<RepositoryUrl>https://github.com/newky2k/Cloneable</RepositoryUrl>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<IsRoslynComponent>true</IsRoslynComponent>
+		<Version>2.0.0</Version>
+		<PackageProjectUrl>https://github.com/newky2k/Cloneable</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageLicenceUrl>https://github.com/newky2k/Cloneable/blob/master/LICENCE</PackageLicenceUrl>
+		<RepositoryType>git</RepositoryType>
+		<IsPackable>true</IsPackable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="tools\%(Filename)%(Extension)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="../README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\LoDaTek.Cloneable.Core\LoDaTek.Cloneable.Core.csproj" />
+	</ItemGroup>
+</Project>

--- a/Cloneable/SymbolExtensions.cs
+++ b/Cloneable/SymbolExtensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Cloneable
+namespace LoDaTek.Cloneable
 {
     internal static class SymbolExtensions
     {

--- a/Cloneable/SyntaxReceiver.cs
+++ b/Cloneable/SyntaxReceiver.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Created on demand before each generation pass
 /// </summary>
-namespace Cloneable
+namespace LoDaTek.Cloneable
 {
     internal class SyntaxReceiver : ISyntaxReceiver
     {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <Version>1.3.0.0</Version>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <!--<PropertyGroup>
     <OutputPath>..\Output\$(Configuration)</OutputPath>
-  </PropertyGroup>
+  </PropertyGroup>-->
 </Project>

--- a/LoDaTek.Cloneable.Core/CloneAttribute.cs
+++ b/LoDaTek.Cloneable.Core/CloneAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LoDaTek.Cloneable.Core
+{
+    /// <summary>
+    /// CloneAttribute. This class cannot be inherited.
+    /// Implements the <see cref="Attribute" />
+    /// </summary>
+    /// <seealso cref="Attribute" />
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public sealed class CloneAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloneAttribute"/> class.
+        /// </summary>
+        public CloneAttribute()
+        {
+
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [prevent deep copy].
+        /// </summary>
+        /// <value><c>true</c> if [prevent deep copy]; otherwise, <c>false</c>.</value>
+        public bool PreventDeepCopy { get; set; }
+    }
+}

--- a/LoDaTek.Cloneable.Core/CloneableAttribute.cs
+++ b/LoDaTek.Cloneable.Core/CloneableAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace LoDaTek.Cloneable.Core
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = true, AllowMultiple = false)]
+    public sealed class CloneableAttribute : Attribute
+    {
+        public CloneableAttribute()
+        {
+        }
+
+        public bool ExplicitDeclaration { get; set; }
+    }
+}

--- a/LoDaTek.Cloneable.Core/IgnoreCloneAttribute.cs
+++ b/LoDaTek.Cloneable.Core/IgnoreCloneAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LoDaTek.Cloneable.Core
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public sealed class IgnoreCloneAttribute : Attribute
+    {
+        public IgnoreCloneAttribute()
+        {
+
+        }
+    }
+}

--- a/LoDaTek.Cloneable.Core/LoDaTek.Cloneable.Core.csproj
+++ b/LoDaTek.Cloneable.Core/LoDaTek.Cloneable.Core.csproj
@@ -1,32 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
 	<PropertyGroup>
-		<Authors>Nicholas Brostrom</Authors>
+		<Authors>newky2k</Authors>
 		<Description>Auto-generator of Clone method using C# Source Generator</Description>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<RepositoryUrl>https://github.com/Nickztar/Cloneable</RepositoryUrl>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-		<IsRoslynComponent>true</IsRoslynComponent>
 		<Version>2.0.0</Version>
 		<PackageProjectUrl>https://github.com/Nickztar/Cloneable</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenceUrl>https://github.com/Nickztar/Cloneable/blob/master/LICENCE</PackageLicenceUrl>
 		<RepositoryType>git</RepositoryType>
 		<IsPackable>true</IsPackable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-		<None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="tools\%(Filename)%(Extension)" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
-	</ItemGroup>
-	<ItemGroup>
 		<None Include="../README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
+	
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloneable
 
-This is a fork of https://github.com/mostmand/Cloneable - Which doesn't seem to be maintained...
+This is a fork of https://github.com/Nickztar/Cloneable which is a fork of https://github.com/mostmand/Cloneable - Which doesn't seem to be maintained...
 
 Auto generate Clone method using C# Source Generator
 
@@ -10,11 +10,11 @@ This source generator saves your time by generating the boilerplate code for clo
 ### Installing Cloneable
 You should install [Cloneable with NuGet](https://www.nuget.org/packages/Cloneable.Generator):
 
-    Install-Package Cloneable.Generator
+    Install-Package LoDaTek.Cloneable
     
 Or via the .NET Core command line interface:
 
-    dotnet add package Cloneable.Generator
+    dotnet add package LoDaTek.Cloneable
 
 Either commands, from Package Manager Console or .NET Core CLI, will download and install Cloneable and all required dependencies.
 

--- a/azure-pipelines-mergetest.yml
+++ b/azure-pipelines-mergetest.yml
@@ -1,0 +1,29 @@
+# .NET Desktop
+# Build and run tests for .NET Desktop or Windows classic desktop solutions.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
+
+trigger: none
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:  
+- task: NuGetToolInstaller@1
+  displayName: Install Latest Nuget
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'restore'
+    projects: '*.sln'
+  
+- task: DotNetCoreCLI@2
+  displayName: dotnet build
+  inputs:
+    projects: '$(solution)'
+    arguments: '--configuration=$(buildConfiguration) /p:Platform="$(buildPlatform)"'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,0 +1,54 @@
+# .NET Desktop
+# Build and run tests for .NET Desktop or Windows classic desktop solutions.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    - '*.yml'
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+  netVersion: '6.0.x'
+  releaseSuffix: ''
+
+name: 3.3.$(date:yyMM).$(date:dd)$(rev:r)
+steps:
+- task: NuGetToolInstaller@1
+  displayName: Install Latest Nuget
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'restore'
+    projects: '$(solution)'
+  
+- task: DotNetCoreCLI@2
+  displayName: dotnet build
+  inputs:
+    projects: '$(solution)'
+    arguments: '--configuration=$(buildConfiguration) /p:Platform="$(buildPlatform)" /p:Version=$(Build.BuildNumber) /p:AssemblyVersion=$(Build.BuildNumber) /p:FileVersion=$(Build.BuildNumber) '
+    
+- task: CopyFiles@2
+  displayName: Copy Files to $(build.artifactstagingdirectory)
+  inputs:
+    SourceFolder: '$(system.defaultworkingdirectory)'
+    Contents: '**/LoDaTek.*.nupkg'
+    TargetFolder: '$(build.artifactstagingdirectory)'
+    flattenFolders: true
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Artifacts drop
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: 'drop'
+    publishLocation: 'Container'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -22,7 +22,7 @@ variables:
   netVersion: '6.0.x'
   releaseSuffix: ''
 
-name: 3.3.$(date:yyMM).$(date:dd)$(rev:r)
+name: 3.0.$(date:yyMM).$(date:dd)$(rev:r)
 steps:
 - task: NuGetToolInstaller@1
   displayName: Install Latest Nuget


### PR DESCRIPTION
Moved the attribute class into seperate project to avoid duplication and naming collisions when referencing projects that also use the Cloneable generators.